### PR TITLE
Changed misleading documentation.

### DIFF
--- a/sqlalchemy_wrapper/main.py
+++ b/sqlalchemy_wrapper/main.py
@@ -55,7 +55,7 @@ class SQLAlchemy(object):
 
     .. sourcecode:: python
 
-        db = SQLAlchemy()
+        db = SQLAlchemy('sqlite://')
 
         app = Flask(__name__)
         db.init_app(app)


### PR DESCRIPTION
As per issue #15 the DATABASE_URI must be passed in as the first parameter of SQLAlchemy().

The documentation was confusing.