### PR TITLE
add "poolclass" parameter

### DIFF
--- a/sqlalchemy_wrapper/main.py
+++ b/sqlalchemy_wrapper/main.py
@@ -69,7 +69,7 @@ class SQLAlchemy(object):
     """
 
     def __init__(self, uri='sqlite://', app=None, echo=False,
-                 pool_size=None, pool_timeout=None, pool_recycle=None,
+                 pool_size=None, pool_timeout=None, pool_recycle=None, poolclass=None,
                  convert_unicode=True, isolation_level=None,
                  record_queries=False, metadata=None, metaclass=None,
                  query_cls=BaseQuery, model_class=Model, **session_options):
@@ -81,6 +81,7 @@ class SQLAlchemy(object):
             pool_size=pool_size,
             pool_timeout=pool_timeout,
             pool_recycle=pool_recycle,
+            poolclass=poolclass,
             convert_unicode=convert_unicode,
             isolation_level=isolation_level,
         )

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -3,6 +3,7 @@ from datetime import datetime
 import mock
 import pytest
 
+from sqlalchemy import pool
 from sqlalchemy_wrapper import SQLAlchemy
 from sqlalchemy_wrapper.helpers import _BoundDeclarativeMeta
 
@@ -238,3 +239,14 @@ def test_custom_metaclass():
     db.create_all()
 
     assert Model.test == 1
+
+
+def test_custom_poolclass():
+
+    class _CustomPool(pool.StaticPool):
+        _do_return_conn = mock.MagicMock()
+
+    db = SQLAlchemy(URI1, poolclass=_CustomPool)
+    db.create_all()
+
+    _CustomPool._do_return_conn.assert_called_once()


### PR DESCRIPTION
Hello!
I want to allow passing "poolclass" parameter to create_engine() .
In my project I have to patching or subclassing original SQLAlchemy class for change it.

Also flask-sqlachemy has the same issue:
https://github.com/mitsuhiko/flask-sqlalchemy/issues/266
