### PR TITLE
create_engine() falls with mysql and something pool classes

### DIFF
--- a/sqlalchemy_wrapper/main.py
+++ b/sqlalchemy_wrapper/main.py
@@ -6,6 +6,7 @@ try:
     from sqlalchemy.ext.declarative import declarative_base
     from sqlalchemy.orm import scoped_session, sessionmaker
     from sqlalchemy.schema import MetaData
+    from sqlalchemy.util.langhelpers import get_cls_kwargs
 except ImportError:  # pragma: no cover
     raise ImportError(
         'Unable to load the sqlalchemy package.'
@@ -135,7 +136,9 @@ class SQLAlchemy(object):
         """
         if self.info.drivername == 'mysql':
             self.info.query.setdefault('charset', 'utf8')
-            options.setdefault('pool_size', 10)
+            poolclass = options.get('poolclass')
+            if poolclass is None or 'pool_size' in get_cls_kwargs(poolclass):
+                options.setdefault('pool_size', 10)
             options.setdefault('pool_recycle', 7200)
 
         elif self.info.drivername == 'sqlite':

--- a/sqlalchemy_wrapper/main.py
+++ b/sqlalchemy_wrapper/main.py
@@ -6,7 +6,7 @@ try:
     from sqlalchemy.ext.declarative import declarative_base
     from sqlalchemy.orm import scoped_session, sessionmaker
     from sqlalchemy.schema import MetaData
-    from sqlalchemy.util.langhelpers import get_cls_kwargs
+    from sqlalchemy.util import get_cls_kwargs
 except ImportError:  # pragma: no cover
     raise ImportError(
         'Unable to load the sqlalchemy package.'

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -250,3 +250,8 @@ def test_custom_poolclass():
     db.create_all()
 
     _CustomPool._do_return_conn.assert_called_once()
+
+
+def test_mysql_apply_driver_hacks():
+    with mock.patch('sqlalchemy.dialects.mysql.mysqldb.MySQLDialect_mysqldb.dbapi'):
+        SQLAlchemy('mysql://', poolclass=pool.Pool)

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -250,9 +250,3 @@ def test_custom_poolclass():
     db.create_all()
 
     _CustomPool._do_return_conn.assert_called_once()
-
-
-def test_mysql_apply_driver_hacks():
-    with mock.patch('sqlalchemy.dialects.mysql.mysqldb.MySQLDialect_mysqldb.dbapi'):
-        with mock.patch('sqlalchemy.util.langhelpers.compat.inspect_getargspec'):
-            SQLAlchemy('mysql://', poolclass=pool.Pool)

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -254,4 +254,5 @@ def test_custom_poolclass():
 
 def test_mysql_apply_driver_hacks():
     with mock.patch('sqlalchemy.dialects.mysql.mysqldb.MySQLDialect_mysqldb.dbapi'):
-        SQLAlchemy('mysql://', poolclass=pool.Pool)
+        with mock.patch('sqlalchemy.util.langhelpers.compat.inspect_getargspec'):
+            SQLAlchemy('mysql://', poolclass=pool.Pool)


### PR DESCRIPTION
Hello!

Something pool classes such as NullPool, StaticPool not supports 'pool_size' argument.
Following code produces an error:

`SQLAlchemy('mysql://...', poolclass=NullPool)`

`TypeError: Invalid argument(s) 'pool_size' sent to create_engine(), using configuration MySQLDialect_mysqldb/NullPool/Engine.  Please check that the keyword arguments are appropriate for this combination of components.`

My patch checks arguments of pool class `__init__` function for fix it.
That's little dirty, but removing problem part from `apply_driver_hacks` may produce unexpected consequences.
