### PR TITLE
Allow to change engine and session configuration after init

### DIFF
--- a/sqlalchemy_wrapper/main.py
+++ b/sqlalchemy_wrapper/main.py
@@ -117,6 +117,28 @@ class SQLAlchemy(object):
         ])
         return self.apply_driver_hacks(options)
 
+    def reconfigure(self, uri=None, echo=False,
+                    pool_size=None, pool_timeout=None, pool_recycle=None, poolclass=None,
+                    convert_unicode=True, isolation_level=None, **session_options):
+
+        if uri is not None:
+            self.uri = uri
+            self.info = make_url(uri)
+
+        self.options = self._cleanup_options(
+            echo=echo,
+            pool_size=pool_size,
+            pool_timeout=pool_timeout,
+            pool_recycle=pool_recycle,
+            poolclass=poolclass,
+            convert_unicode=convert_unicode,
+            isolation_level=isolation_level,
+        )
+
+        self.session.remove()
+        session_options.setdefault('bind', self.engine)
+        self.session.configure(**session_options)
+
     def make_declarative_base(self, model_class, metadata=None, metaclass=None):
         """Creates the declarative base."""
         return declarative_base(


### PR DESCRIPTION
It may be useful for unit tests.
Short example for py.test:
```
@pytest.fixture(scope='function', autouse=True)
def clean_up_db():
    # called before all test functions
    db.reconfigure(uri='sqlite://', echo=True)
    db.drop_all()
    db.create_all()

def test_something():
    db.add(Item())
    db.commit()
    ...
```

Also related to #24 cause we can not read Flask-SQLAlchemy's `app.config`