### PR TITLE
Fix setting "bind" for session

### DIFF
--- a/sqlalchemy_wrapper/main.py
+++ b/sqlalchemy_wrapper/main.py
@@ -97,6 +97,7 @@ class SQLAlchemy(object):
             self.uri = uri
             self.info = make_url(uri)
 
+        self.session_options.pop('bind', None)
         for arg in get_cls_kwargs(Session):
             if arg in options:
                 self.session_options[arg] = options.pop(arg)

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -6,6 +6,7 @@ import pytest
 from sqlalchemy import pool
 from sqlalchemy_wrapper import SQLAlchemy
 from sqlalchemy_wrapper.helpers import _BoundDeclarativeMeta, BaseQuery
+from sqlalchemy.exc import OperationalError
 
 URI1 = 'sqlite://'
 URI2 = 'sqlite://'
@@ -269,7 +270,9 @@ def test_reconfigure(tmpdir):
     uri = 'sqlite:///%s' % tmp_db_file.strpath.replace('\\', '/')
     db.reconfigure(uri=uri, echo=True, query_cls=CustomQuery)
 
-    assert not Model.__table__.exists(db.engine)
+    with pytest.raises(OperationalError):
+        db.query(Model).count()
+
     assert (uri, True) == db.connector._connected_for
     assert isinstance(db.query(Model), CustomQuery)
     assert db.query(Model).some_attr == 1


### PR DESCRIPTION
Sorry, I've missed this moment when implementing `reconfigure`.
But it may be easily fixed with:
```python
db.session_options.pop('bind')
db.reconfigure(uri=uri, **options)
```